### PR TITLE
Fixing some bugs and some redesign

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/roqua/physiqual.git
-  revision: 899825bcfaff73b9aa48d563efb12d2401f49509
+  revision: 86ce2e1390c76e9cf506f1bd402df8a572226621
   specs:
     physiqual (0.0.1)
       active_interaction (~> 2.1.2)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,7 @@
  *= require_self
  */
 #forkme {
+  width: 149px;
   position: absolute;
   text-align: right;
   top: 0;
@@ -22,6 +23,6 @@
 }
 
 .forkme-image {
-  width:50%;
-  height:50%;
+  width:100%;
+  height:100%;
 }

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -1,3 +1,22 @@
-// Place all the styles related to the welcome controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+.promo {
+  width: 100%;
+}
+@media only screen and (max-width : 992px) {
+  .promo {
+    width: 60%;
+    margin: 0 auto;
+    display: block;
+  }
+}
+.promo i {
+  margin: 40px 0;
+  color: #ee6e73;
+  font-size: 7rem;
+  display: block;
+}
+.promo-caption {
+  font-size: 1.7rem;
+  font-weight: 500;
+  margin-top: 5px;
+  margin-bottom: 0;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,18 +13,18 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/js/materialize.min.js"></script>
   </head>
   <body>
-    <nav>
+    <nav class="light-blue lighten-2">
       <div class="nav-wrapper container">
-        <a href="http://www.physiqual.com" class="brand-logo">Physiqual
+        <a href="/" class="brand-logo">Physiqual
           <i style="display:inline; font-size:0.5em" class="hide-on-med-and-down">Let me hear your body talk...</i></a>
         <a href="#" data-activates="mobile" class="button-collapse"><i class="material-icons">menu</i></a>
 
         <ul id="nav-mobile" class="right hide-on-med-and-down">
-          <li><%= link_to 'Login', welcome_index_path %></li>
+          <li><%= link_to 'Login', root_path %></li>
           <li><%= link_to 'Example', welcome_example_path %></li>
         </ul>
         <ul class="side-nav" id="mobile">
-          <li><%= link_to 'Login', welcome_index_path %></li>
+          <li><%= link_to 'Login', root_path %></li>
           <li><%= link_to 'Example', welcome_example_path %></li>
           <li><a href="https://github.com/roqua/physiqual" target="_blank">Github</a></li>
         </ul>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,32 +1,37 @@
+<div class="section">
 <div class="row">
-  <h3 class="col s12 light center header">Physiqual, where sensors and self-report meets.</h3>
+  <h3 class="col s12 light center header orange-text">Where Sensors and Self-Report Meet</h3>
+  <h5 class="center header col s12 light">Physiqual is a framework for resampling, imputing, and unifying health and fitness data</h5>
 </div>
+</div>
+<div class="section">
 <div class="row">
   <div class="col s12 m4 flow-text center">
-    <i class="large material-icons">insert_chart</i>
+    <i class="large material-icons light-blue-text">insert_chart</i>
     <p class="promo-caption">Easy to use</p>
-    <p class="light center"> Inform the participants, run the study, and export their data. It's as easy as 1,2,3.</p>
+    <p class="light center"> Inform the participants, run the study, and export their data. It's as easy as 1, 2, 3.</p>
   </div>
   <div class="col s12 m4 flow-text center">
-    <i class="large material-icons">cloud</i>
+    <i class="large material-icons light-blue-text">cloud</i>
     <p class="promo-caption">Reliable</p>
     <p class="light center"> Relies on the cloud services provided by large service providers.</p>
   </div>
   <div class="col s12 m4 flow-text center">
-    <div class="center promo">
-      <i class="large material-icons">view_carousel</i>
-      <p class="promo-caption">Multiplatform</p>
-      <p class="light center"> Supports both Fitbit and Google Fit, and can be extended to other platforms.</p>
-    </div>
+    <i class="large material-icons light-blue-text">view_carousel</i>
+    <p class="promo-caption">Multiplatform</p>
+    <p class="light center"> Supports both Fitbit and Google Fit, and can be extended to other platforms.</p>
   </div>
 </div>
+</div>
 <div class="divider"></div>
+<div class="section">
 <div class="row center">
   <h3 class="light header">Supported service providers</h3>
   <div class="col s6 flow-text center">
-    <p><%= link_to 'google', physiqual.authorize_oauth_session_index_path(provider: 'google', params: {email: 'framando@physiqual.com'}), class: 'waves-effect waves-light btn'%> </p>
+    <p><%= link_to 'google', physiqual.authorize_oauth_session_index_path(provider: 'google', params: {email: 'framando@physiqual.com'}), class: 'waves-effect waves-light btn orange'%> </p>
   </div>
   <div class="col s6 flow-text center">
-    <p><%= link_to 'fitbit', physiqual.authorize_oauth_session_index_path(provider: 'fitbit'), class: 'waves-effect waves-light btn'%></p>
+    <p><%= link_to 'fitbit', physiqual.authorize_oauth_session_index_path(provider: 'fitbit'), class: 'waves-effect waves-light btn orange'%></p>
   </div>
+</div>
 </div>

--- a/config/initializers/physiqual.rb
+++ b/config/initializers/physiqual.rb
@@ -12,9 +12,9 @@ Physiqual.configure do |config|
   config.host_protocol        = ENV['HOST_PROTOCOL'] || 'http'
 
   # EMA Settings
-  config.measurements_per_day = 3 # Number of measurements per day, from the end of day downwards
-  config.interval             = 6 # Number of hours between measurements
-  config.use_night            = false # Should the night be included in the first measurement of the day, if there was no questionnaire
+  config.measurements_per_day           = 3 # Number of measurements per day, from the end of day downwards
+  config.interval                       = 6 # Number of hours between measurements
+  config.hours_before_first_measurement = 6 # Should the night be included in the first measurement of the day, if there was no questionnaire
 
   # Imputation
   # List of imputers to use, prefix with Physiqual::Imputers::, choose from:


### PR DESCRIPTION
- fixed forkme link overlaying the links in the menubar at small screen sizes because the image was scaled to 50% of the containing div
- fixed initializer from throwing errors because use_night no longer exists (updated physiqual gem revision in Gemfile)
- link in main banner now redirects to / instead of www.physiqual.com, login now redirects to root_path instead of welcome_index_path
- added the css for the promo headers which are not included in the default materialize css
- redid the color scheme
- rephrased header text

### Before
![before](https://cloud.githubusercontent.com/assets/607965/10542315/a248625e-7417-11e5-95d9-8c9efc251a8a.jpg)


### After
![after](https://cloud.githubusercontent.com/assets/607965/10542316/a382e428-7417-11e5-9cd5-6e0322bd7a18.jpg)
