### PR TITLE
Bugfixes and better flow for the welcome page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/roqua/physiqual.git
-  revision: 8298f09cc21677e29c7254fc68cc81ef9e021f5a
+  revision: 3e7815c71503efa5f6ef461e4327fa8a6c946d77
   specs:
     physiqual (0.0.1)
       active_interaction (~> 2.1.2)
@@ -122,7 +122,7 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -130,9 +130,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
-    omniauth (1.2.2)
+    omniauth (1.3.1)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     omniauth-fitbit-oauth2 (1.0.0)
       omniauth-oauth2 (~> 1.3)
     omniauth-google-oauth2 (0.2.10)
@@ -228,10 +228,10 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/roqua/physiqual.git
-  revision: 3e7815c71503efa5f6ef461e4327fa8a6c946d77
+  revision: f16b44d8e16aea1fa0c1081b7d6ae2edb31950b6
   specs:
     physiqual (0.0.1)
       active_interaction (~> 2.1.2)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Metrics/ClassLength, Metrics/MethodLength
 class WelcomeController < ApplicationController
+  include WelcomeHelper
+
   def index
   end
 

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,2 +1,23 @@
 module WelcomeHelper
+  NUMBER_OF_SUPPORTED_SERVICES = 2
+
+  def current_user
+    Physiqual::User.find_by_user_id(session[:physiqual_user_id])
+  end
+
+  def logged_in?
+    session[:physiqual_user_id] && current_user
+  end
+
+  def number_of_tokens
+    current_user.physiqual_tokens.size
+  end
+
+  def fitbit_token?
+    current_user.fitbit_tokens.size > 0
+  end
+
+  def google_token?
+    current_user.google_tokens.size > 0
+  end
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -10,14 +10,17 @@ module WelcomeHelper
   end
 
   def number_of_tokens
+    # precondition: user is logged in (logged_in?)
     current_user.physiqual_tokens.size
   end
 
   def fitbit_token?
+    # precondition: user is logged in (logged_in?)
     current_user.fitbit_tokens.size > 0
   end
 
   def google_token?
+    # precondition: user is logged in (logged_in?)
     current_user.google_tokens.size > 0
   end
 end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,44 +1,69 @@
 <div class="section">
-<div class="row">
-  <h3 class="col s12 light center header orange-text">Where Sensors and Self-Report Meet</h3>
-  <h5 class="center header col s12 light">Physiqual is a framework for resampling, imputing, and unifying health and fitness data</h5>
-</div>
+  <div class="row">
+    <h3 class="col s12 light center header orange-text">Where Sensors and Self-Report Meet</h3>
+    <h5 class="center header col s12 light">Physiqual is a framework for resampling, imputing, and unifying health and
+      fitness data</h5>
+  </div>
 </div>
 <div class="section">
-<div class="row">
-  <div class="col s12 m4 flow-text center">
-    <i class="large material-icons light-blue-text">insert_chart</i>
-    <p class="promo-caption">Easy to use</p>
-    <p class="light center"> Inform the participants, run the study, and export their data. It's as easy as 1, 2, 3.</p>
-  </div>
-  <div class="col s12 m4 flow-text center">
-    <i class="large material-icons light-blue-text">cloud</i>
-    <p class="promo-caption">Reliable</p>
-    <p class="light center"> Relies on the cloud services provided by large service providers.</p>
-  </div>
-  <div class="col s12 m4 flow-text center">
-    <i class="large material-icons light-blue-text">view_carousel</i>
-    <p class="promo-caption">Multiplatform</p>
-    <p class="light center"> Supports both Fitbit and Google Fit, and can be extended to other platforms.</p>
+  <div class="row">
+    <div class="col s12 m4 flow-text center">
+      <i class="large material-icons light-blue-text">insert_chart</i>
+      <p class="promo-caption">Easy to use</p>
+      <p class="light center"> Inform the participants, run the study, and export their data. It's as easy as 1, 2,
+        3.</p>
+    </div>
+    <div class="col s12 m4 flow-text center">
+      <i class="large material-icons light-blue-text">cloud</i>
+      <p class="promo-caption">Reliable</p>
+      <p class="light center"> Relies on the cloud services provided by large service providers.</p>
+    </div>
+    <div class="col s12 m4 flow-text center">
+      <i class="large material-icons light-blue-text">view_carousel</i>
+      <p class="promo-caption">Multiplatform</p>
+      <p class="light center"> Supports both Fitbit and Google Fit, and can be extended to other platforms.</p>
+    </div>
   </div>
 </div>
-</div>
-<div class="divider"></div>
-<div class="section">
-<div class="row center">
-  <% if session[:physiqual_user_id] %>
-    <h3 class="light header">Get an overview of your recent fitness data</h3>
-    <div class="col s6 flow-text center">
-      <p><%= link_to 'google', '/physiqual/auth/physiqual_google_oauth2/authorize?return_url=%2Fphysiqual%2Fexports.html%3Ffirst_measurement%3D2015-10-07%252010%3A00%26number_of_days%3D5', class: 'waves-effect waves-light btn orange'%> </p>
-    </div>
-    <div class="col s6 flow-text center">
-      <p><%= link_to 'fitbit', '/physiqual/auth/physiqual_fitbit_oauth2/authorize?return_url=%2Fphysiqual%2Fexports.html%3Ffirst_measurement%3D2015-10-07%252010%3A00%26number_of_days%3D5', class: 'waves-effect waves-light btn orange'%></p>
-    </div>
-  <% else %>
-    <h3 class="light header">Log in with your Google account</h3>
-    <div class="col s12 flow-text center">
-      <p><%= link_to 'Login', "/auth/google_oauth2", class: 'waves-effect waves-light btn orange'%> </p>
+<% if logged_in? %>
+  <% unless number_of_tokens == 0 %>
+    <div class="divider"></div>
+    <div class="section">
+      <div class="row center">
+        <h3 class="light header">Get an overview of your recent fitness data</h3>
+        <div class="col s12 flow-text center">
+          <p><%= link_to 'Show me', '/physiqual/exports.html?first_measurement=2015-10-07 10:00&number_of_days=5', class: 'waves-effect waves-light btn orange', data: {"no-turbolink" => true} %></p>
+        </div>
+      </div>
     </div>
   <% end %>
-</div>
-</div>
+  <% unless number_of_tokens == WelcomeHelper::NUMBER_OF_SUPPORTED_SERVICES %>
+    <% column_size = 12 / (WelcomeHelper::NUMBER_OF_SUPPORTED_SERVICES - number_of_tokens) %>
+    <div class="divider"></div>
+    <div class="section">
+      <div class="row center">
+        <h3 class="light header">Add data from a service provider</h3>
+        <% unless google_token? %>
+          <div class="<%= "col s#{column_size} flow-text center" %>">
+            <p><%= link_to 'google', '/physiqual/auth/physiqual_google_oauth2/authorize?return_url=%2Fphysiqual%2Fexports.html%3Ffirst_measurement%3D2015-10-07%252010%3A00%26number_of_days%3D5', class: 'waves-effect waves-light btn orange' %> </p>
+          </div>
+        <% end %>
+        <% unless fitbit_token? %>
+          <div class="<%= "col s#{column_size} flow-text center" %>">
+            <p><%= link_to 'fitbit', '/physiqual/auth/physiqual_fitbit_oauth2/authorize?return_url=%2Fphysiqual%2Fexports.html%3Ffirst_measurement%3D2015-10-07%252010%3A00%26number_of_days%3D5', class: 'waves-effect waves-light btn orange' %></p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <div class="divider"></div>
+  <div class="section">
+    <div class="row center">
+      <h3 class="light header">Log in with your Google account</h3>
+      <div class="col s12 flow-text center">
+        <p><%= link_to 'Login', "/auth/google_oauth2", class: 'waves-effect waves-light btn orange' %> </p>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
- Updated the Physiqual gem to the current revision.

- Fixes the double requests for data when clicking on the overview. This bug was fixed by disabling turbolinks for this one hyperlink.

- The welcome page only shows buttons to add information from specific service providers if the user does not already have a token with those service providers.

- The button to show the overview is now separate from the buttons to add data from service providers.

- Adding data from service providers is now more transparently labeled (has its own heading), which disappears if the user has tokens for all supported service providers.

- If the user has only a Google token, but no FitBit token (or vice versa), only the button to add data from FitBit is shown under the "Add data from a service provider" heading.
