### PR TITLE
Update dependencies (Gemnasium auto-update a62ef55c660715fc74c51a7757aa155c6b85953c)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,9 +156,9 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parser (2.3.1.2)
+    parser (2.3.1.4)
       ast (~> 2.2)
-    pg (0.18.4)
+    pg (0.19.0)
     pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -205,10 +205,10 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (11.3.0)
     rdoc (4.2.2)
       json (~> 1.4)
-    rspec-core (3.5.2)
+    rspec-core (3.5.3)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -216,7 +216,7 @@ GEM
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
-    rspec-rails (3.5.1)
+    rspec-rails (3.5.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -225,7 +225,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.42.0)
+    rubocop (0.43.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -248,7 +248,7 @@ GEM
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -263,7 +263,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.1.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -306,7 +306,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.2.4p230
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -10,6 +10,6 @@ module WelcomeHelper
 
   def token?
     # precondition: user is logged in (logged_in?)
-    current_user && current_user.physiqual_token
+    current_user&.physiqual_token
   end
 end


### PR DESCRIPTION
Update dependencies:
rake: 11.2.2 => 11.3.0
rspec-rails: 3.5.1 => 3.5.2
pg: 0.18.4 => 0.19.0
rspec-core: 3.5.2 => 3.5.3
sprockets-rails: 3.1.1 => 3.2.0
unicode-display_width: 1.1.0 => 1.1.1
rubocop: 0.42.0 => 0.43.0
parser: 2.3.1.2 => 2.3.1.4